### PR TITLE
Implement std::io::IntoInnerError-like interface for IntoInnerError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl<W> From<IntoInnerError<W>> for io::Error {
     fn from(iie: IntoInnerError<W>) -> io::Error { iie.1 }
 }
 
-impl<W: Send + fmt::Debug> error::Error for IntoInnerError<W> {
+impl<W: fmt::Debug> error::Error for IntoInnerError<W> {
     fn description(&self) -> &str {
         error::Error::description(self.error())
     }


### PR DESCRIPTION
Duplicated interface and trait inheritance of `std::io::IntoInnerError`. Nice to have it implement `std::error::Error` for integrating nicely with error-handling.